### PR TITLE
Add optional large status bar font

### DIFF
--- a/mobile/app-screenshot-tests/src/test/snapshots/images/__ToolsScreenPreview.png
+++ b/mobile/app-screenshot-tests/src/test/snapshots/images/__ToolsScreenPreview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:948f915c4044d037d2dfd67633aa3693b7f0320032efee831fa09bc002038fb5
-size 17308
+oid sha256:7b5d04fcad38ebe898ab622cd68e1cbc4af66379428f60ebb3c00791e6376114
+size 19158

--- a/mobile/app-screenshot-tests/src/test/snapshots/images/__ToolsScreenPreview_night.png
+++ b/mobile/app-screenshot-tests/src/test/snapshots/images/__ToolsScreenPreview_night.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cec0676aa86939db030a1b5525d5ceee7143a1c6fce27e0764a0f3a4ac7afed2
-size 17939
+oid sha256:e510fbf7f9c071855ab6fa8cd71ebef3c8010a38899356007b06ffb0e9f2ba75
+size 19914

--- a/mobile/bluetooth/data/src/main/kotlin/com/matejdro/pebblenotificationcenter/bluetooth/WatchSyncerImpl.kt
+++ b/mobile/bluetooth/data/src/main/kotlin/com/matejdro/pebblenotificationcenter/bluetooth/WatchSyncerImpl.kt
@@ -162,6 +162,9 @@ class WatchSyncerImpl(
             if (preferences[GlobalPreferenceKeys.turnOnBacklight]) {
                flags = flags or 0x08
             }
+            if (preferences[GlobalPreferenceKeys.largeStatusBarFont]) {
+               flags = flags or 0x10
+            }
 
             val autoClose = preferences[GlobalPreferenceKeys.autoCloseSeconds]
 

--- a/mobile/bluetooth/data/src/test/kotlin/com/matejdro/pebblenotificationcenter/bluetooth/WatchSyncerImplTest.kt
+++ b/mobile/bluetooth/data/src/test/kotlin/com/matejdro/pebblenotificationcenter/bluetooth/WatchSyncerImplTest.kt
@@ -559,6 +559,32 @@ class WatchSyncerImplTest {
    }
 
    @Test
+   fun `Send updated large status bar font preference`() = scope.runTest {
+      init(enablePreferences = true)
+      delay(2.seconds)
+
+      preferences.edit {
+         it[GlobalPreferenceKeys.largeStatusBarFont] = true
+      }
+      delay(2.seconds)
+
+      bucketSyncRepository.awaitNextUpdate(0u, emptyList()) shouldBe BucketUpdate(
+         2u,
+         listOf(1u),
+         listOf(
+            Bucket(
+               1u,
+               byteArrayOf(
+                  0b00010000, // Only large status bar font enabled
+                  0,
+                  0,
+               )
+            )
+         )
+      )
+   }
+
+   @Test
    fun `Send updated auto close`() = scope.runTest {
       init(enablePreferences = true)
       delay(2.seconds)

--- a/mobile/rules/api/src/main/kotlin/com/matejdro/pebblenotificationcenter/rules/GlobalPreferenceKeys.kt
+++ b/mobile/rules/api/src/main/kotlin/com/matejdro/pebblenotificationcenter/rules/GlobalPreferenceKeys.kt
@@ -17,4 +17,6 @@ object GlobalPreferenceKeys {
    val scrollWrapAround = BooleanPreferenceKeyWithDefault("wrap_around_scroll", true)
 
    val turnOnBacklight = BooleanPreferenceKeyWithDefault("turn_on_backlight", false)
+
+   val largeStatusBarFont = BooleanPreferenceKeyWithDefault("large_status_bar_font", false)
 }

--- a/mobile/tools/ui/src/main/kotlin/com/matejdro/pebblenotificationcenter/tools/ui/ToolsScreen.kt
+++ b/mobile/tools/ui/src/main/kotlin/com/matejdro/pebblenotificationcenter/tools/ui/ToolsScreen.kt
@@ -261,6 +261,17 @@ private fun ToolsScreenContent(
          }
 
          item(span = { GridItemSpan(maxLineSpan) }) {
+            SwitchPreference(
+               state.preferences[GlobalPreferenceKeys.largeStatusBarFont],
+               onValueChange = {
+                  updatePreference(GlobalPreferenceKeys.largeStatusBarFont, it)
+               },
+               title = { Text(stringResource(R.string.setting_large_status_bar_font)) },
+               summary = { Text(stringResource(R.string.setting_large_status_bar_font_description)) }
+            )
+         }
+
+         item(span = { GridItemSpan(maxLineSpan) }) {
             Text(
                stringResource(R.string.version, state.versionName),
                Modifier

--- a/mobile/tools/ui/src/main/res/values/strings.xml
+++ b/mobile/tools/ui/src/main/res/values/strings.xml
@@ -25,4 +25,8 @@
     <string name="setting_turn_on_backlight_description">When enabled, watch will automatically turn on the backlight every time
         it vibrates for a new notification.
     </string>
+    <string name="setting_large_status_bar_font">Large status bar font</string>
+    <string name="setting_large_status_bar_font_description">Use a larger font for the clock in the watch status bar so the
+        time is easier to read. Takes effect the next time a screen is opened on the watch.
+    </string>
 </resources>

--- a/protocol.md
+++ b/protocol.md
@@ -177,6 +177,7 @@ Bucket data:
   * 0x02 - Phone mute on or off
   * 0x04 - When set, scrolling wrap-around is disabled
   * 0x08 - When set, watch will turn on backlight on vibration
+  * 0x10 - Large status bar font on or off
 * Auto close seconds (uint16)
   * 0 means disabled
 

--- a/watch/src/ui/layers/status_bar.c
+++ b/watch/src/ui/layers/status_bar.c
@@ -4,7 +4,15 @@
 #include "commons/connection/bucket_sync.h"
 #include "connection/notification_details_fetcher.h"
 
-static const int STATUS_BAR_HEIGHT = 16;
+// The status bar grows to fit the clock font. The "large font" mode (toggled from the phone's Tools menu and
+// delivered via bucket 1 flag 0x10) uses GOTHIC_18 instead of GOTHIC_14 so the clock is easier to read.
+#define STATUS_BAR_HEIGHT_SMALL 16
+#define STATUS_BAR_HEIGHT_LARGE 22
+#define CLOCK_WIDTH_SMALL 48
+#define CLOCK_WIDTH_LARGE 62
+#define CLOCK_FONT_SMALL FONT_KEY_GOTHIC_14
+#define CLOCK_FONT_LARGE FONT_KEY_GOTHIC_18
+#define ICON_AREA_WIDTH 14
 
 // Emery (and presumably future Core devices with larger displays) have a pretty big corner radius. And since there's
 // more display real estate, we can afford to make some padding on the right
@@ -14,8 +22,24 @@ static const int STATUS_BAR_HEIGHT = 16;
 #define CORNER_PADDING 0
 #endif
 
-#define CLOCK_WIDTH 48
-static const int STATUS_BAR_RIGHT_WIDTH = CLOCK_WIDTH + 1 + 14 + 1 + CORNER_PADDING;
+// Width consumed on the right side of the bar (clock + 1px gap + status icon + 1px gap + corner padding) for a given
+// clock width. The clock width is stored in the layer's data so both the paint proc and get_left_space agree on it.
+static int status_bar_right_width(const int clock_width)
+{
+    return clock_width + 1 + ICON_AREA_WIDTH + 1 + CORNER_PADDING;
+}
+
+// Reads the "large font" preference from bucket 1 (byte 0, flag 0x10). Falls back to the small font when the bucket
+// has not been synced from the phone yet.
+static bool status_bar_large_font_enabled(void)
+{
+    uint8_t config[3];
+    if (bucket_sync_load_bucket(1, config))
+    {
+        return (config[0] & 0x10) != 0;
+    }
+    return false;
+}
 
 static CustomStatusBarLayer* active_layer;
 static bool listeners_active = false;
@@ -31,12 +55,20 @@ static void update_data();
 
 CustomStatusBarLayer* custom_status_bar_layer_create(const GRect window_frame)
 {
-    Layer* layer = layer_create(GRect(0, 0, window_frame.size.w, STATUS_BAR_HEIGHT));
+    const bool large_font = status_bar_large_font_enabled();
+    const int status_bar_height = large_font ? STATUS_BAR_HEIGHT_LARGE : STATUS_BAR_HEIGHT_SMALL;
+    const int clock_width = large_font ? CLOCK_WIDTH_LARGE : CLOCK_WIDTH_SMALL;
+    const char* clock_font = large_font ? CLOCK_FONT_LARGE : CLOCK_FONT_SMALL;
+
+    // Store the clock width in the layer's data so the paint proc and get_left_space can reconstruct the geometry.
+    Layer* layer = layer_create_with_data(GRect(0, 0, window_frame.size.w, status_bar_height), sizeof(uint8_t));
+    *(uint8_t*)layer_get_data(layer) = (uint8_t)clock_width;
+
     TextLayer* clock_layer = text_layer_create(
-        GRect(window_frame.size.w - CLOCK_WIDTH - CORNER_PADDING - 1, 0, CLOCK_WIDTH - 1, STATUS_BAR_HEIGHT));
+        GRect(window_frame.size.w - clock_width - CORNER_PADDING - 1, 0, clock_width - 1, status_bar_height));
     text_layer_set_background_color(clock_layer, GColorClear);
     text_layer_set_text_color(clock_layer, GColorWhite);
-    text_layer_set_font(clock_layer, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+    text_layer_set_font(clock_layer, fonts_get_system_font(clock_font));
     text_layer_set_text_alignment(clock_layer, GTextAlignmentRight);
 
     layer_add_child(layer, text_layer_get_layer(clock_layer));
@@ -65,19 +97,25 @@ static void custom_status_bar_paint(Layer* layer, GContext* ctx)
     graphics_fill_rect(ctx, layer_get_frame(layer), 0, GCornerNone);
 
     const GRect whole_status_size = layer_get_bounds(layer);
+    const int bar_height = whole_status_size.size.h;
+    const uint8_t clock_width = *(uint8_t*)layer_get_data(layer);
 
-    const uint16_t icon_x = whole_status_size.size.w - CLOCK_WIDTH - 1 - 14 - CORNER_PADDING;
+    const uint16_t icon_x = whole_status_size.size.w - clock_width - 1 - ICON_AREA_WIDTH - CORNER_PADDING;
+    // Vertically center the indicators within the bar (matches the original 16px-tall layout where the 13px and 10px
+    // icons sat at y=1 and y=3 respectively).
+    const int large_icon_y = (bar_height - 13) / 2;
+    const int small_icon_y = (bar_height - 10) / 2;
     if (sending_error != APP_MSG_OK)
     {
-        graphics_draw_bitmap_in_rect(ctx, indicator_error, GRect(icon_x + 3, 3, 9, 10));
+        graphics_draw_bitmap_in_rect(ctx, indicator_error, GRect(icon_x + 3, small_icon_y, 9, 10));
     }
     else if (!is_phone_connected)
     {
-        graphics_draw_bitmap_in_rect(ctx, indicator_disconnected, GRect(icon_x, 1, 14, 13));
+        graphics_draw_bitmap_in_rect(ctx, indicator_disconnected, GRect(icon_x, large_icon_y, 14, 13));
     }
     else if (is_currently_sending_data || bucket_sync_is_currently_syncing || notification_details_fetcher_is_fetching())
     {
-        graphics_draw_bitmap_in_rect(ctx, indicator_busy, GRect(icon_x + 3, 3, 9, 10));
+        graphics_draw_bitmap_in_rect(ctx, indicator_busy, GRect(icon_x + 3, small_icon_y, 9, 10));
     }
 }
 
@@ -171,6 +209,7 @@ static void update_data()
 GRect custom_status_bar_get_left_space(CustomStatusBarLayer* layer)
 {
     const GRect whole_status_size = layer_get_bounds(layer->layer);
+    const uint8_t clock_width = *(uint8_t*)layer_get_data(layer->layer);
 
     return (GRect)
     {
@@ -181,7 +220,7 @@ GRect custom_status_bar_get_left_space(CustomStatusBarLayer* layer)
         },
         .
         size = {
-            .w = whole_status_size.size.w - STATUS_BAR_RIGHT_WIDTH - CORNER_PADDING,
+            .w = whole_status_size.size.w - status_bar_right_width(clock_width) - CORNER_PADDING,
             .h = whole_status_size.size.h
         }
     };


### PR DESCRIPTION
## What

Adds an optional **Large status bar font** setting (in the Tools screen). When enabled, the watch renders the status-bar clock in `GOTHIC_18` instead of `GOTHIC_14`, growing the status bar and clock box to fit, so the time is easier to read for users who find the default 14pt too small. Pebble has no `GOTHIC_16`, so 18 is the next system size up.

## How

- New global preference `largeStatusBarFont` in `GlobalPreferenceKeys`, surfaced as a `SwitchPreference` on the Tools screen.
- Delivered to the watch via the existing bucket-1 settings flags byte, new bit **`0x10`** (`0x01`/`0x02`/`0x04`/`0x08` are already used by watch mute / phone mute / wrap-around / backlight). Documented in `protocol.md`.
- `WatchSyncerImpl.syncPreferences()` OR's in `FLAG_LARGE_STATUS_BAR_FONT` (`0x10`).
- Watch `status_bar.c` reads bucket 1 byte 0, flag `0x10`; when set it uses `GOTHIC_18` and grows the bar `16 → 22px` and clock box `48 → 62px`. Falls back to the small font if the bucket hasn't synced from the phone yet. Takes effect the next time a screen is opened on the watch (not live).

## Testing

- Unit test `Send updated large status bar font preference` (`WatchSyncerImplTest`) asserts the `0b00010000` bucket byte.
- Paparazzi `ToolsScreen` snapshots re-recorded for the new toggle.
- Manually verified end-to-end on a Pebble Time 2.

## Notes

- The flag bit is `0x10` specifically to avoid colliding with the wrap-around (`0x04`) and backlight (`0x08`) flags that already occupy this byte.