### PR TITLE
Add per-rule "hide subtitle" option

### DIFF
--- a/mobile/app-screenshot-tests/src/test/snapshots/images/__AllPreferencesPreview.png
+++ b/mobile/app-screenshot-tests/src/test/snapshots/images/__AllPreferencesPreview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ec7b734d44e8bdd19e3dea1d3dea7dedc4acf10fff620e48f509249bbf340ba
-size 38261
+oid sha256:bbd256774404e6ca9e7066982c6d1e561b7aa48a211b1ec65b10f75bdb0ba5ee
+size 40505

--- a/mobile/app-screenshot-tests/src/test/snapshots/images/__AllPreferencesPreview_night.png
+++ b/mobile/app-screenshot-tests/src/test/snapshots/images/__AllPreferencesPreview_night.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc8261e3dc49158f56e32c5bcdb8faeeea8eb6c22d1f408defaf514953f9881f
-size 39987
+oid sha256:dd21fa8f7d10a383fb8851efb818696d8a70894e437150e98f32024ec76b813d
+size 42150

--- a/mobile/notification/api/src/main/kotlin/com/matejdro/pebblenotificationcenter/notification/model/ParsedNotification.kt
+++ b/mobile/notification/api/src/main/kotlin/com/matejdro/pebblenotificationcenter/notification/model/ParsedNotification.kt
@@ -37,6 +37,12 @@ data class ParsedNotification(
    val largeImage: Any? = null,
    val id: Int = 0,
    val tag: String? = null,
+   /**
+    * The raw conversation/group title (e.g. a group chat's participant list) that was merged into [body] because it
+    * was too long to fit as a subtitle; empty when the title fit as the subtitle. Used to strip it out of the body
+    * when a rule has "hide subtitle" enabled.
+    */
+   val conversationTitle: String = "",
 )
 
 data class NativeAction(

--- a/mobile/notification/data/src/androidTest/kotlin/com/matejdro/pebblenotificationcenter/notification/parsing/NotificationParserTest.kt
+++ b/mobile/notification/data/src/androidTest/kotlin/com/matejdro/pebblenotificationcenter/notification/parsing/NotificationParserTest.kt
@@ -55,6 +55,30 @@ class NotificationParserTest {
    }
 
    @Test
+   fun parseNotificationWithLongTitleMergesTitleIntoBodyAndKeepsConversationTitle() {
+      // A title longer than the subtitle limit is dropped from the subtitle and prepended to the body. The raw
+      // title is kept in conversationTitle so a rule with "hide subtitle" can strip it back out of the body.
+      val longTitle = "Group Chat: Alice, Bob, Carol"
+      val notification = NotificationCompat.Builder(context, "TEST_CHANNEL")
+         .setContentTitle(longTitle)
+         .setContentText("Alice: Hello")
+         .setSmallIcon(0)
+         .setShowWhen(false)
+         .build()
+
+      notificationParser.parse(notification.toSbn(), createDefaultSilentChannel()) shouldBe ParsedNotification(
+         "0|com.matejdro.pebblenotificationcenter.notification.parsing|0|null|0",
+         TEST_PACKAGE,
+         "SMS App",
+         "",
+         "$longTitle\nAlice: Hello",
+         Instant.ofEpochMilli(0L),
+         channel = testChannelOrNull(),
+         conversationTitle = longTitle,
+      )
+   }
+
+   @Test
    fun parseNotificationWithoutTitle() {
       val notification = NotificationCompat.Builder(context, "TEST_CHANNEL")
          .setContentText("Description")
@@ -314,6 +338,7 @@ class NotificationParserTest {
          "A very very long long title title\nDescription",
          Instant.ofEpochMilli(0L),
          channel = testChannelOrNull(),
+         conversationTitle = "A very very long long title title",
       )
    }
 

--- a/mobile/notification/data/src/main/kotlin/com/matejdro/pebblenotificationcenter/notification/NotificationProcessor.kt
+++ b/mobile/notification/data/src/main/kotlin/com/matejdro/pebblenotificationcenter/notification/NotificationProcessor.kt
@@ -80,12 +80,7 @@ class NotificationProcessor(
          pauseStatusBeforeInsert
       )
 
-      val regexesToReplace = settings[RuleOption.regexReplacements]
-      val regexReplacedParsedNotification = parsedNotification.copy(
-         title = replaceRegexes(parsedNotification.title, regexesToReplace),
-         subtitle = replaceRegexes(parsedNotification.subtitle, regexesToReplace),
-         body = replaceRegexes(parsedNotification.body, regexesToReplace),
-      )
+      val regexReplacedParsedNotification = applyTextRules(parsedNotification, settings)
 
       val initialProcessedNotification = ProcessedNotification(
          regexReplacedParsedNotification,
@@ -114,6 +109,38 @@ class NotificationProcessor(
       insertIntoHistory(settings, regexReplacedParsedNotification, affectedRules, hideReason, muteReason)
       notifications[bucketId] = processedNotification
       notificationIdsByKeys[parsedNotification.key] = bucketId
+   }
+
+   /**
+    * Applies a rule's text transforms to a notification: regex replacements, and (when "hide subtitle" is on)
+    * blanking the subtitle and stripping the conversation/group title that the parser merged into the body.
+    */
+   private fun applyTextRules(parsed: ParsedNotification, settings: Preferences): ParsedNotification {
+      val regexesToReplace = settings[RuleOption.regexReplacements]
+      val hideSubtitle = settings[RuleOption.hideSubtitle]
+      val body = if (hideSubtitle) {
+         removeConversationTitle(body = parsed.body, conversationTitle = parsed.conversationTitle)
+      } else {
+         parsed.body
+      }
+      return parsed.copy(
+         title = replaceRegexes(parsed.title, regexesToReplace),
+         subtitle = if (hideSubtitle) "" else replaceRegexes(parsed.subtitle, regexesToReplace),
+         body = replaceRegexes(body, regexesToReplace),
+      )
+   }
+
+   /**
+    * Removes the conversation/group title from the body. The parser prepends a too-long title to the body as its
+    * own line, so we handle both "title\nactual body" and a body that is only the title.
+    */
+   private fun removeConversationTitle(body: String, conversationTitle: String): String {
+      if (conversationTitle.isBlank()) return body
+      return when {
+         body == conversationTitle -> ""
+         body.startsWith("$conversationTitle\n") -> body.removePrefix("$conversationTitle\n")
+         else -> body
+      }
    }
 
    private fun shouldHide(

--- a/mobile/notification/data/src/main/kotlin/com/matejdro/pebblenotificationcenter/notification/parsing/NotificationParser.kt
+++ b/mobile/notification/data/src/main/kotlin/com/matejdro/pebblenotificationcenter/notification/parsing/NotificationParser.kt
@@ -36,7 +36,7 @@ class NotificationParser(
       val title = appNameProvider.getAppName(sbn.packageName)
 
       val (imageUri, messagingStyleText) = notification.parseMessagingStyle(showMessagingStyleChronologically)
-      val (subtitle, text) = parseSubtitleAndBody(notification, messagingStyleText)
+      val (conversationTitle, subtitle, text) = parseSubtitleAndBody(notification, messagingStyleText)
 
       if (subtitle.isBlank() && text.isNullOrBlank()) {
          return null
@@ -69,6 +69,7 @@ class NotificationParser(
          title = title,
          subtitle = subtitleWithCameraEmoji,
          body = text.orEmpty(),
+         conversationTitle = conversationTitle,
          timestamp = Instant.ofEpochMilli(notification.parseMessagingStyleTimestamp() ?: timestampMillis),
          isSilent = isSilent,
          isFilteredByDoNotDisturb = ranking?.matchesInterruptionFilter() == false,
@@ -89,7 +90,7 @@ class NotificationParser(
    private fun parseSubtitleAndBody(
       notification: Notification,
       messagingStyleText: String?,
-   ): Pair<String, String?> {
+   ): ParsedSubtitleBody {
       val extras = notification.extras
 
       val subtitle = (
@@ -111,16 +112,21 @@ class NotificationParser(
             )
             ?.removeUselessCharacaters()
 
-      val updatedSubtitle: CharSequence
-      val updatedText: CharSequence?
+      val conversationTitle: String
+      val updatedSubtitle: String
+      val updatedText: String?
       if (subtitle.length > MAX_TITLE_LENGTH) {
+         // The title is too long to fit as a subtitle, so it is merged into the body. Keep the raw title so
+         // callers can strip it from the body when "hide subtitle" is enabled.
+         conversationTitle = subtitle
          updatedSubtitle = ""
          updatedText = if (text != null) "$subtitle\n$text" else subtitle
       } else {
+         conversationTitle = ""
          updatedSubtitle = subtitle
          updatedText = text
       }
-      return updatedSubtitle to updatedText
+      return ParsedSubtitleBody(conversationTitle = conversationTitle, subtitle = updatedSubtitle, body = updatedText)
    }
 
    private fun processChannel(notification: Notification, channel: Any?): Pair<String?, Boolean> {
@@ -240,3 +246,9 @@ private fun parseVibrationPattern(notification: Notification): List<Short>? {
 
 private const val MAX_TITLE_LENGTH = 20
 private val CONTROL_CHARACTERS = Regex("\\p{Cf}|\\p{M}")
+
+private data class ParsedSubtitleBody(
+   val conversationTitle: String,
+   val subtitle: String,
+   val body: String?,
+)

--- a/mobile/notification/data/src/test/kotlin/com/matejdro/pebblenotificationcenter/notification/NotificationProcessorTest.kt
+++ b/mobile/notification/data/src/test/kotlin/com/matejdro/pebblenotificationcenter/notification/NotificationProcessorTest.kt
@@ -103,6 +103,55 @@ class NotificationProcessorTest {
    }
 
    @Test
+   fun `It should blank the subtitle when hide subtitle is enabled`() = runTest {
+      rulesRepository.updateRulePreferences(
+         RULE_ID_DEFAULT_SETTINGS,
+         RuleOption.hideSubtitle setTo true
+      )
+
+      val notification = ParsedNotification(
+         "key",
+         "com.app",
+         "Title",
+         "sTitle",
+         "Body",
+         Instant.ofEpochSecond(1_767_554_305)
+      )
+
+      processor.onNotificationPosted(notification)
+
+      val synced = watchSyncer.syncedNotifications.first().systemData
+      assertSoftly {
+         synced.subtitle shouldBe ""
+         synced.body shouldBe "Body"
+      }
+   }
+
+   @Test
+   fun `It should strip the conversation title from the body when hide subtitle is enabled`() = runTest {
+      rulesRepository.updateRulePreferences(
+         RULE_ID_DEFAULT_SETTINGS,
+         RuleOption.hideSubtitle setTo true
+      )
+
+      // A long group title is merged into the body by the parser (subtitle left blank); hiding the subtitle must
+      // also remove that title line from the body, otherwise a group chat still shows the participant list.
+      val notification = ParsedNotification(
+         "key",
+         "com.app",
+         "Title",
+         "",
+         "Group Chat: Alice, Bob, Carol\nAlice: Hello",
+         Instant.ofEpochSecond(1_767_554_305),
+         conversationTitle = "Group Chat: Alice, Bob, Carol",
+      )
+
+      processor.onNotificationPosted(notification)
+
+      watchSyncer.syncedNotifications.first().systemData.body shouldBe "Alice: Hello"
+   }
+
+   @Test
    fun `It should forward notification deletions to the watch syncer`() = runTest {
       val notification = ParsedNotification(
          "key",

--- a/mobile/rules/api/src/main/kotlin/com/matejdro/pebblenotificationcenter/rules/RuleOption.kt
+++ b/mobile/rules/api/src/main/kotlin/com/matejdro/pebblenotificationcenter/rules/RuleOption.kt
@@ -48,6 +48,10 @@ object RuleOption {
    val subtitleFont = EnumPreferenceKeyWithDefault("font_subtitle", PebbleFont.GOTHIC_14_BOLD)
    val bodyFont = EnumPreferenceKeyWithDefault("font_body", PebbleFont.GOTHIC_14)
 
+   // When enabled, the notification's subtitle (e.g. a group chat's participant list) is dropped before sending to
+   // the watch. The "who said what" lives in the body for messaging notifications, so this just removes the noise.
+   val hideSubtitle = BooleanPreferenceKeyWithDefault("hide_subtitle", false)
+
    val autoAppPause = BooleanPreferenceKeyWithDefault("auto_app_pause", false)
    val autoConversationPause = BooleanPreferenceKeyWithDefault("auto_conversation_pause", false)
 

--- a/mobile/rules/ui/src/main/kotlin/com/matejdro/pebblenotificationcenter/rules/ui/details/Settings.kt
+++ b/mobile/rules/ui/src/main/kotlin/com/matejdro/pebblenotificationcenter/rules/ui/details/Settings.kt
@@ -113,6 +113,13 @@ internal fun ColumnScope.Settings(
          fontNames,
       )
 
+      SwitchPreference(
+         value = preferences[RuleOption.hideSubtitle],
+         onValueChange = { updatePreference(RuleOption.hideSubtitle, it) },
+         title = { Text(stringResource(R.string.setting_hide_subtitle)) },
+         summary = { Text(stringResource(R.string.setting_hide_subtitle_description)) }
+      )
+
       RegexReplacementSetPreference(navigator, updatePreference, preferences)
 
       SwitchPreference(

--- a/mobile/rules/ui/src/main/res/values/strings.xml
+++ b/mobile/rules/ui/src/main/res/values/strings.xml
@@ -99,6 +99,10 @@
     <string name="preference_font_title">Title font</string>
     <string name="preference_font_subtitle">Subtitle font</string>
     <string name="preference_font_body">Body font</string>
+    <string name="setting_hide_subtitle">Hide subtitle</string>
+    <string name="setting_hide_subtitle_description">Don\'t send the notification subtitle to the watch. Useful for group chats,
+        where the subtitle is the participant list — the sender and message stay in the body.
+    </string>
     <string name="setting_periodic_vibration">Periodic vibration</string>
     <string name="setting_periodic_vibration_description">When enabled, after notification vibrates for the first time, it will
         also make a periodic short buzz. \n\nPressing any button will stop this until the next notification with this enabled is


### PR DESCRIPTION
I'm back with another one trying to make my NC2 experience even better!

## What

Adds a per-rule **Hide subtitle** option (in a rule's Settings). When enabled, the notification subtitle is dropped before the notification is sent to the watch.

The motivating case is that sometimes the subtitle is long and unhelpful and clutters the notification.

## How

- New per-rule preference `RuleOption.hideSubtitle` (`hide_subtitle`, default `false`), surfaced as a `SwitchPreference` in the rule Settings screen.
- When enabled, `NotificationProcessor` blanks the subtitle field.
- Group-chat edge case: a conversation/group title longer than `MAX_TITLE_LENGTH` is merged by the parser into the *body* (prepended as `"title\n…"`), so blanking the subtitle field alone wouldn't hide it for group chats. To handle that, `ParsedNotification` now carries the raw `conversationTitle` (the parser's `parseSubtitleAndBody` returns a `Triple`), and `NotificationProcessor.removeConversationTitle()` strips that `"title\n"` prefix (or the whole body when the body *is* just the title) when the option is on.

## Testing

- Manually verified on a Pebble Time 2: a group-chat rule with **Hide subtitle** on shows only the sender + message, with the participant list removed from both subtitle and body.
- Paparazzi settings snapshots re-recorded for the new toggle.