### PR TITLE
feat(watch): make the large status bar clock GOTHIC_24_BOLD

### DIFF
--- a/watch/src/ui/layers/status_bar.c
+++ b/watch/src/ui/layers/status_bar.c
@@ -5,13 +5,13 @@
 #include "connection/notification_details_fetcher.h"
 
 // The status bar grows to fit the clock font. The "large font" mode (toggled from the phone's Tools menu and
-// delivered via bucket 1 flag 0x10) uses GOTHIC_18 instead of GOTHIC_14 so the clock is easier to read.
+// delivered via bucket 1 flag 0x10) uses GOTHIC_24_BOLD instead of GOTHIC_14 so the clock is easier to read.
 #define STATUS_BAR_HEIGHT_SMALL 16
-#define STATUS_BAR_HEIGHT_LARGE 22
+#define STATUS_BAR_HEIGHT_LARGE 30
 #define CLOCK_WIDTH_SMALL 48
-#define CLOCK_WIDTH_LARGE 62
+#define CLOCK_WIDTH_LARGE 86
 #define CLOCK_FONT_SMALL FONT_KEY_GOTHIC_14
-#define CLOCK_FONT_LARGE FONT_KEY_GOTHIC_18
+#define CLOCK_FONT_LARGE FONT_KEY_GOTHIC_24_BOLD
 #define ICON_AREA_WIDTH 14
 
 // Emery (and presumably future Core devices with larger displays) have a pretty big corner radius. And since there's


### PR DESCRIPTION
I realized that somehow the font that was on the watchapp when I was testing this was GOTHIC_24_BOLD instead of GOTHIC_18.  I blame it on the fact that I've lost most of my coding skills and now have to rely on communicating with a robot in English to get things done. :) 

## What

The optional "large status bar font" toggle currently bumps the clock only from `GOTHIC_14` to `GOTHIC_18` — a small step. This makes the "large" mode use `GOTHIC_24_BOLD` instead, so it's meaningfully more readable, growing the status bar height (16 → 30px) and the clock box (48 → 86px) to fit.

## How

A one-file change in the watchapp (`status_bar.c`): the large-mode font, bar height, and clock width. **No app, protocol, or preference changes** — the existing Tools toggle and the bucket-1 `0x10` flag are untouched, so existing "large font on" users simply get a bigger clock after the watchapp updates.
